### PR TITLE
gitlab-ci schema: Optimize items of the workflow rules array

### DIFF
--- a/src/schemas/json/gitlab-ci.json
+++ b/src/schemas/json/gitlab-ci.json
@@ -61,13 +61,17 @@
         "rules": {
           "type": "array",
           "items": {
-            "if": {
-              "type": "string"
+            "type": "object",
+            "properties": {
+              "if": {
+                "type": "string"
+              },
+              "when": {
+                "type": "string",
+                "enum": ["always", "never"]
+              }
             },
-            "when": {
-              "type": "string",
-              "enum": ["always", "never"]
-            }
+            "additionalProperties": false
           }
         }
       }


### PR DESCRIPTION
* Instead of defining the properties of a rule on the top level of the items entry define a whole object (compare https://json-schema.org/learn/miscellaneous-examples.html for the definition of "An array of objects")
* Added `additionalProperties` (only the `if` and the `when` properties are accepted https://docs.gitlab.com/ee/ci/yaml/#workflowrules, additional added properties lead to a yml validation error "workflow:rules:rule config contains unknown keys: xyz")